### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ parking_lot = ["dep:parking_lot"]
 
 [dependencies]
 bitflags = "1"
-parking_lot = { version = "0", optional = true }
-spin = { version = "0", optional = true }
+parking_lot = { version = "0.12", optional = true }
+spin = { version = "0.9", optional = true }


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.